### PR TITLE
fix: rename misspelled 'epliog' to 'epilog' in sink types

### DIFF
--- a/include/logovod/core.h
+++ b/include/logovod/core.h
@@ -50,7 +50,7 @@ struct basic_sink_types {
     using epiloger = std::size_t(*)(attributes, std::basic_ostream<CharT, Traits>&) noexcept;
     prologer prolog;
     writer_type writer;
-    epiloger epliog;
+    epiloger epilog;
 };
 
 namespace sink {
@@ -534,7 +534,7 @@ struct runtime_sink : Base {
   static void sink(sink::bundle bundle) noexcept {
       prolog_ = bundle.prolog;
       writer_ = bundle.writer;
-      epilog_ = bundle.epliog;
+      epilog_ = bundle.epilog;
   }
   static void sink(prologer p, writer_type w, epiloger e) noexcept {
       prolog_ = p;

--- a/include/logovod/optional.h
+++ b/include/logovod/optional.h
@@ -50,7 +50,7 @@ struct optional_sink : Base {
   static void sink(sink::bundle bundle) noexcept {
       prolog_ = bundle.prolog;
       writer_ = bundle.writer;
-      epilog_ = bundle.epliog;
+      epilog_ = bundle.epilog;
   }
   static void sink(prologer p, writer_type w, epiloger e) noexcept {
       prolog_ = p;


### PR DESCRIPTION
## Summary
Rename the misspelled field name 'epliog' to 'epilog' in the sink types.

## Changes
- `include/logovod/core.h`: rename `epliog` field → `epilog` (line 53) and `bundle.epliog` → `bundle.epilog` (line 537)
- `include/logovod/optional.h`: fix `bundle.epliog` → `bundle.epilog` (lines 53, 57)

## Why
Issue #3 reports that `bundle::epilog` is misspelled as `epliog`. The field name should be 'epilog' to match the semantic purpose and the existing namespace `sink::epilog`.

Fixes #3