### PR TITLE
fix: include chrono.h in attributer.h to resolve put_time_point

### DIFF
--- a/include/logovod/sink/attributer.h
+++ b/include/logovod/sink/attributer.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <logovod/core.h>
+#include <logovod/chrono.h>
 #include <chrono>
 #include <filesystem>
 


### PR DESCRIPTION
## Fix: Include chrono.h in attributer.h

### Problem
 uses  (line 40) but does not include  where this function is defined. This causes compilation errors when including  without first including .

### Reproduction
```cpp
#include <logovod/sink/attributer.h>  // error: 'put_time_point' is not a member of 'logovod::detail'
int main() { return 0; }
```

### Fix
Add  to .

### Testing
Compiled successfully with  after the fix.

Closes #4