### PR TITLE
fix: correct make install path for headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ build:
 	
 
 install: #!   Installs headers at DESTDIR
-	install -d $(DESTDIR:%=%/logovod)
-	cp -r include/logovod $(DESTDIR:%=%/logovod)
+	install -d $(DESTDIR)/logovod
+	cp -r include/logovod $(DESTDIR)
 
 package: #!   Assembles deb package
 	@rm -rf $(BUILDDIR)/$(LOGOVOD_DEB)


### PR DESCRIPTION
## Fix: Correct make install path for headers

### Problem
`make install` creates `/usr/include/logovod/logovod/` instead of `/usr/include/logovod/`. The Makefile substitution pattern was incorrect.

### Root Cause
The install rule used:
```
install -d $(DESTDIR:%=%/logovod)
cp -r include/logovod $(DESTDIR:%=%/logovod)
```
This creates a nested `logovod` directory inside the target directory.

### Fix
Changed to:
```
install -d $(DESTDIR)/logovod
cp -r include/logovod $(DESTDIR)
```
This creates the correct path structure.

### Testing
Verified with DESTDIR=/tmp/test:
- Before fix: `/tmp/test/logovod/logovod/*.h` (nested)
- After fix: `/tmp/test/logovod/*.h` (correct)

Closes #2