### PR TITLE
fix: correct make install path for headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ build:
 	
 
 install: #!   Installs headers at DESTDIR
-	install -d $(DESTDIR:%=%/logovod)
-	cp -r include/logovod $(DESTDIR:%=%/logovod)
+	install -d $(DESTDIR)
+	cp -r include/logovod $(DESTDIR)
 
 package: #!   Assembles deb package
 	@rm -rf $(BUILDDIR)/$(LOGOVOD_DEB)


### PR DESCRIPTION
## Fix: Correct make install path for headers

### Problem
make install creates /usr/include/logovod/logovod/ instead of /usr/include/logovod/

### Root Cause
The Makefile substitution pattern was incorrect.

### Fix (per maintainer review)
Changed to install directly to DESTDIR without the extra /logovod suffix:
```make
install -d 
cp -r include/logovod 
```

### Verification
- DESTDIR=/tmp/test: creates /tmp/test/logovod/*.h (correct, no nesting)
- Matches standard make install conventions

Closes #2